### PR TITLE
changing from Oauth to Basic auth; making openapi.json valid by addin…

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -20,7 +20,11 @@
         "summary": "Should fetch variables from defaults and user values",
         "description": "",
         "parameters": [],
-        "responses": {},
+        "responses": {
+          "200": {
+            "description": "show defaults"
+          }
+        },
         "security": [
           {
             "apiKey": []
@@ -32,7 +36,8 @@
   "components": {
     "securitySchemes": {
       "apiKey": {
-        "type": "oauth2"
+        "type": "http",
+        "scheme": "basic"
       }
     }
   },
@@ -40,3 +45,8 @@
   "x-samples-enabled": true,
   "x-samples-languages": ["curl", "node", "ruby", "javascript", "python"]
 }
+
+
+
+
+

--- a/readme-login.js
+++ b/readme-login.js
@@ -11,13 +11,14 @@ module.exports = (req, res) => {
   // Validate email and password is a correct user, and get the user information
 
   // User being logged into ReadMe
-  // At this point we have a valid user, so we are sending them to readme
+  // FE at this point we're hardcoding in a user's name to mock sending a valid 
+  //At this point we have a valid user, so we are sending them to readme
   var user = {
     name: email,
     email: email,
     
     // User's API Key
-    apiKey: 'test_123sldoih',
+    apiKey: { user: 'testUser', pass: '123pass' },
     
     version: 1, // Required, if omited things can break unexpectedly
 
@@ -28,7 +29,6 @@ module.exports = (req, res) => {
   var jwt = sign(user, process.env.JWT_SECRET);
   var url = new URL(process.env.HUB_URL);
   url.searchParams.set('auth_token', jwt);
-
   console.log('Redirecting to: ', url.toString());
   return res.redirect(url);
 }

--- a/readme-login.js
+++ b/readme-login.js
@@ -11,13 +11,12 @@ module.exports = (req, res) => {
   // Validate email and password is a correct user, and get the user information
 
   // User being logged into ReadMe
-  // FE at this point we're hardcoding in a user's name to mock sending a valid 
-  //At this point we have a valid user, so we are sending them to readme
+  // At this point we're hardcoding in a user's name to mock sending in a valid user
   var user = {
     name: email,
     email: email,
     
-    // User's API Key
+    // User's API Key (OR) { user, pass }
     apiKey: { user: 'testUser', pass: '123pass' },
     
     version: 1, // Required, if omited things can break unexpectedly


### PR DESCRIPTION
Sorry, I was running out of time and didn't test this throughly, but I did verify that 1) I was able to upload the openapi.json through my project's dash (in the master branch, the openapi.json is NOT valid) and 2) I saw my API authorization stuff prepopulate at:
 https://trial-fe.readme.io/reference#post_post-1 
