### PR TITLE
these changes pass the redirect through 

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (req, res) => {
-  return res.render('index')
+  return res.render('index', { redirect: req.query.redirect || '' });
 });
 
 app.post('/', readmeLogin);

--- a/readme-login.js
+++ b/readme-login.js
@@ -5,6 +5,7 @@ var { URL } = require('url');
 // This should do all of the work to login and verify the user is valid
 module.exports = (req, res) => {
   var { email, password } = req.body;
+  var redirect = req.body.redirect || req.query.redirect;
 
   console.log('Use these credentials to log the user in somewhere:', { email, password });
 
@@ -28,6 +29,7 @@ module.exports = (req, res) => {
   var jwt = sign(user, process.env.JWT_SECRET);
   var url = new URL(process.env.HUB_URL);
   url.searchParams.set('auth_token', jwt);
+  if (redirect) url.searchParams.set('redirect', redirect);
   console.log('Redirecting to: ', url.toString());
   return res.redirect(url);
 }

--- a/views/index.jade
+++ b/views/index.jade
@@ -3,6 +3,7 @@ extends layout
 block content
   h1 Demo Login
   form(method='POST')
+    input(type='hidden', name='redirect', value=redirect)
     .form-group
       label Email
       input.form-control(name='email' required value='test@example.com')


### PR DESCRIPTION
....when cashing in the token so the user ends up where they started when they clicked "log in"

## 🧰 Changes

Currently, when they click "login" the source URL doesn't propagate through

## 🧬 QA & Testing

It works when both the redirect param is present at the login screen and not, you can try both scenarios
